### PR TITLE
fix: make snapshot write_source_files update target public visibility

### DIFF
--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -1,3 +1,17 @@
+load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 
 npm_link_all_packages(name = "node_modules")
+
+# Should be able to aggregate snapshot update targets into a single write_source_files convenience target/
+# Added in https://github.com/aspect-build/rules_jest/pull/93.
+write_source_files(
+    name = "update_all_snapshots",
+    testonly = True,
+    additional_update_targets = [
+        "//example/custom_snapshot_resolver:test_update_snapshots",
+        "//example/custom_snapshot_resolver_files:test_update_snapshots",
+        "//example/snapshots:test_update_snapshots",
+        "//example/snapshots_files:test_update_snapshots",
+    ],
+)

--- a/example/snapshots/BUILD.bazel
+++ b/example/snapshots/BUILD.bazel
@@ -3,6 +3,7 @@
 
 load("@aspect_rules_jest//jest:defs.bzl", "jest_test")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 jest_test(
     name = "test",
@@ -24,6 +25,7 @@ jest_test(
 # The tests and tested are normally in their own targets.
 js_library(
     name = "tests",
+    testonly = True,
     srcs = [
         "greetings.test.js",
         "link.test.js",
@@ -31,7 +33,6 @@ js_library(
     deps = [
         "//example:node_modules/react-test-renderer",
     ],
-    testonly = True,
 )
 
 js_library(
@@ -46,7 +47,6 @@ js_library(
 )
 
 # TEST: Ensure the update_snapshots target builds successfully
-load("@bazel_skylib//rules:build_test.bzl", "build_test")
 build_test(
     name = "update_snapshots_build",
     targets = [":test_update_snapshots"],

--- a/jest/defs.bzl
+++ b/jest/defs.bzl
@@ -274,4 +274,6 @@ def _jest_update_snapshots(
         testonly = True,
         # Tagged manual so it is not built unless run
         tags = tags + ["manual"],
+        # Always public visibility so that it can be used downstream in an aggregate write_source_files target
+        visibility = ["//visibility:public"],
     )


### PR DESCRIPTION
It should be available to any downstream aggregate `write_source_files` targets.

From Bazel slack thread: https://bazelbuild.slack.com/archives/CEZUUKQ6P/p1674589705258479?thread_ts=1674589681.819949&cid=CEZUUKQ6P