### PR TITLE
fix: timeout/size shouldn't be passed to js_binary 

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -9,8 +9,8 @@
 
 <pre>
 jest_test(<a href="#jest_test-name">name</a>, <a href="#jest_test-config">config</a>, <a href="#jest_test-data">data</a>, <a href="#jest_test-snapshots">snapshots</a>, <a href="#jest_test-run_in_band">run_in_band</a>, <a href="#jest_test-colors">colors</a>, <a href="#jest_test-auto_configure_reporters">auto_configure_reporters</a>,
-          <a href="#jest_test-auto_configure_test_sequencer">auto_configure_test_sequencer</a>, <a href="#jest_test-snapshots_ext">snapshots_ext</a>, <a href="#jest_test-quiet_snapshot_updates">quiet_snapshot_updates</a>, <a href="#jest_test-jest_repository">jest_repository</a>,
-          <a href="#jest_test-kwargs">kwargs</a>)
+          <a href="#jest_test-auto_configure_test_sequencer">auto_configure_test_sequencer</a>, <a href="#jest_test-snapshots_ext">snapshots_ext</a>, <a href="#jest_test-quiet_snapshot_updates">quiet_snapshot_updates</a>, <a href="#jest_test-jest_repository">jest_repository</a>, <a href="#jest_test-tags">tags</a>,
+          <a href="#jest_test-timeout">timeout</a>, <a href="#jest_test-size">size</a>, <a href="#jest_test-kwargs">kwargs</a>)
 </pre>
 
 jest_test rule
@@ -36,6 +36,9 @@ Supports updating snapshots with `bazel run {name}_update_snapshots` if `snapsho
 | <a id="jest_test-snapshots_ext"></a>snapshots_ext |  The expected extensions for snapshot files. Defaults to <code>.snap</code>, the Jest default.   |  <code>".snap"</code> |
 | <a id="jest_test-quiet_snapshot_updates"></a>quiet_snapshot_updates |  When True, snapshot update stdout & stderr is hidden when the snapshot update is successful.<br><br>On a snapshot update failure, its stdout & stderr will always be shown.   |  <code>False</code> |
 | <a id="jest_test-jest_repository"></a>jest_repository |  Name of the repository created with jest_repositories().   |  <code>"jest"</code> |
-| <a id="jest_test-kwargs"></a>kwargs |  All other args from <code>js_test</code>. See https://github.com/aspect-build/rules_js/blob/main/docs/js_binary.md#js_test   |  none |
+| <a id="jest_test-tags"></a>tags |  standard Bazel attribute, passed through to generated targets.   |  <code>[]</code> |
+| <a id="jest_test-timeout"></a>timeout |  standard attribute for tests. Defaults to "short" if both timeout and size are unspecified.   |  <code>None</code> |
+| <a id="jest_test-size"></a>size |  standard attribute for tests   |  <code>None</code> |
+| <a id="jest_test-kwargs"></a>kwargs |  Additional named parameters passed to both <code>js_test</code> and <code>js_binary</code>. See https://github.com/aspect-build/rules_js/blob/main/docs/js_binary.md   |  none |
 
 

--- a/example/simple/BUILD.bazel
+++ b/example/simple/BUILD.bazel
@@ -46,6 +46,9 @@ jest_test(
 
 jest_test(
     name = "gen_config_test",
+    # The test takes over a minute, so this will time out.
+    # Change to "moderate" and the test will pass.
+    timeout = "short",
     config = "gen.config.json",
     data = [
         "index.js",
@@ -55,8 +58,8 @@ jest_test(
 
 genrule(
     name = "gen_config",
+    testonly = True,
+    srcs = ["jest.config.json"],
     outs = ["gen.config.json"],
     cmd = "cp $(location :jest.config.json) \"$@\"",
-    srcs = ["jest.config.json"],
-    testonly = True,
 )

--- a/example/simple/BUILD.bazel
+++ b/example/simple/BUILD.bazel
@@ -46,9 +46,6 @@ jest_test(
 
 jest_test(
     name = "gen_config_test",
-    # The test takes over a minute, so this will time out.
-    # Change to "moderate" and the test will pass.
-    timeout = "short",
     config = "gen.config.json",
     data = [
         "index.js",

--- a/example/simple/index.test.js
+++ b/example/simple/index.test.js
@@ -1,5 +1,8 @@
 const index = require(".");
 
-test("it should work", () => {
+jest.setTimeout(100000);
+
+test("it should work", (done) => {
   expect(index).toBe("test");
+  setTimeout(done, 65000);
 });

--- a/example/simple/index.test.js
+++ b/example/simple/index.test.js
@@ -1,8 +1,5 @@
 const index = require(".");
 
-jest.setTimeout(100000);
-
-test("it should work", (done) => {
+test("it should work", () => {
   expect(index).toBe("test");
-  setTimeout(done, 65000);
 });

--- a/example/snapshots/BUILD.bazel
+++ b/example/snapshots/BUILD.bazel
@@ -7,6 +7,7 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 jest_test(
     name = "test",
+    # explicit timeout setting, regression test for #95
     timeout = "moderate",
     config = "jest.config.js",
     data = [

--- a/example/snapshots/BUILD.bazel
+++ b/example/snapshots/BUILD.bazel
@@ -7,6 +7,7 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 jest_test(
     name = "test",
+    timeout = "moderate",
     config = "jest.config.js",
     data = [
         ".babelrc.js",

--- a/jest/defs.bzl
+++ b/jest/defs.bzl
@@ -2,7 +2,7 @@
 """
 
 load("@aspect_bazel_lib//lib:write_source_files.bzl", _write_source_files = "write_source_files")
-load("@aspect_bazel_lib//lib:utils.bzl", "to_label")
+load("@aspect_bazel_lib//lib:utils.bzl", "default_timeout", "to_label")
 load("@aspect_bazel_lib//lib:output_files.bzl", _output_files = "output_files")
 load("@aspect_rules_js//js:defs.bzl", _js_run_binary = "js_run_binary")
 load("@aspect_rules_js//js:libs.bzl", "js_binary_lib")
@@ -62,6 +62,9 @@ def jest_test(
         snapshots_ext = ".snap",
         quiet_snapshot_updates = False,
         jest_repository = "jest",
+        tags = [],
+        timeout = None,
+        size = None,
         **kwargs):
     """jest_test rule
 
@@ -156,10 +159,15 @@ def jest_test(
 
         jest_repository: Name of the repository created with jest_repositories().
 
-        **kwargs: All other args from `js_test`. See https://github.com/aspect-build/rules_js/blob/main/docs/js_binary.md#js_test
-    """
-    tags = kwargs.pop("tags", [])
+        tags: standard Bazel attribute, passed through to generated targets.
 
+        timeout: standard attribute for tests. Defaults to "short" if both timeout and size are unspecified.
+
+        size: standard attribute for tests
+
+        **kwargs: Additional named parameters passed to both `js_test` and `js_binary`.
+            See https://github.com/aspect-build/rules_js/blob/main/docs/js_binary.md
+    """
     snapshot_data = []
     snapshot_files = []
 
@@ -210,6 +218,8 @@ def jest_test(
         auto_configure_reporters = auto_configure_reporters,
         auto_configure_test_sequencer = auto_configure_test_sequencer,
         tags = tags,
+        size = size,
+        timeout = default_timeout(size, timeout),
         **kwargs
     )
 


### PR DESCRIPTION
Fixes #95

BREAKING CHANGE:
The default timeout for jest_test is now short (1m by default) rather than moderate (5m by default).
Tests that take more than 1m should have a size or timeout attribute added.