### PR TITLE
perf: use rules_js Bazel 6 optimized fs patches if using Bazel 6 and experimental_allow_unresolved_symlinks is on

### DIFF
--- a/jest/defs.bzl
+++ b/jest/defs.bzl
@@ -43,6 +43,10 @@ def _jest_from_node_modules(jest_rule, name, node_modules, auto_configure_report
             "@aspect_rules_js//js/private:enable_runfiles": True,
             "//conditions:default": False,
         }),
+        unresolved_symlinks_enabled = select({
+            "@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks": True,
+            "//conditions:default": False,
+        }),
         data = data,
         testonly = True,
         auto_configure_reporters = auto_configure_reporters,


### PR DESCRIPTION
rules_js js_test base attributes that jest_test uses requires setting `unresolved_symlinks_enabled` to True based on the `@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks` condition to enable the optimized Bazel 6 patches only when the user is using Bazel 6 **AND** unresolved symlinks are enabled. They are enabled by default but they can be disabled by the user so we need to check anyway.

**Type of change**

- [x] Performance (a code change that improves performance)

**For changes visible to end-users**

- [x] Breaking change (this change will force users to change their own code or config)

For WORKSPACE users that are pinning `aspect_rules_js`, this bumps the minimum rules_js version required for rules_jest compatibility to 1.24.0. WORKSPACE that get the version of rules_js transitively from `rules_jest_dependencies` are not affected. bzlmod users are also not affected since bzlmod ensure the minimum version of rules_js that rules_jest requires is used.

**Test plan**

- [x] Covered by existing test cases
