### PR TITLE
fix: jest_test rule named the same as the macro

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,4 +1,4 @@
-6.0.0
+6.1.1
 # The first line of this file is used by Bazelisk and Bazel to be sure
 # the right version of Bazel is used to build and test this repo.
 # This also defines which version is used on CI.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Runs tests with the https://jestjs.io/ test runner under Bazel.
 
 rules_jest is just a part of what Aspect provides:
 
--   _Need help?_ This ruleset has support provided by https://aspect.dev.
--   See our other Bazel rules, especially those built for rules_js, such as rules_ts for TypeScript: https://github.com/aspect-build
+- _Need help?_ This ruleset has support provided by https://aspect.dev.
+- See our other Bazel rules, especially those built for rules_js, such as rules_ts for TypeScript: https://github.com/aspect-build
 
 ## Installation
 
@@ -14,6 +14,8 @@ From the release you wish to use:
 copy the WORKSPACE snippet into your `WORKSPACE` file.
 
 ## Usage
+
+Run all Jest tests in the workspace: `bazel test --test_lang_filters=jest //...`
 
 See the documentation in the [docs](docs/) folder and the example usages in the [example](example/) folder.
 

--- a/jest/defs.bzl
+++ b/jest/defs.bzl
@@ -7,23 +7,7 @@ load("@aspect_bazel_lib//lib:write_source_files.bzl", _write_source_files = "wri
 load("@aspect_bazel_lib//lib:utils.bzl", "default_timeout", "to_label")
 load("@aspect_bazel_lib//lib:output_files.bzl", _output_files = "output_files")
 load("@aspect_rules_js//js:defs.bzl", _js_run_binary = "js_run_binary")
-load("@aspect_rules_js//js:libs.bzl", "js_binary_lib")
-load("//jest/private:jest_test.bzl", "lib")
-
-_jest_test = rule(
-    attrs = lib.attrs,
-    implementation = lib.implementation,
-    test = True,
-    toolchains = js_binary_lib.toolchains,
-)
-
-# binary rule used for snapshot updates
-_jest_binary = rule(
-    attrs = lib.attrs,
-    implementation = lib.implementation,
-    executable = True,
-    toolchains = js_binary_lib.toolchains,
-)
+load("//jest/private:jest_test.bzl", jest_binary_rule = "jest_binary", jest_test_rule = "jest_test")
 
 REFERENCE_SNAPSHOT_SUFFIX = "-out"
 REFERENCE_SNAPSHOT_DIRECTORY = "out"
@@ -256,7 +240,7 @@ def jest_test(
 
     # This is the primary {name} jest_test test target
     _jest_from_node_modules(
-        jest_rule = _jest_test,
+        jest_rule = jest_test_rule,
         name = name,
         node_modules = node_modules,
         config = config,
@@ -298,7 +282,7 @@ def jest_test(
         # This is the generated reference snapshot generator binary target that is used as the
         # `tool` in the `js_run_binary` target below to output the reference snapshots.
         _jest_from_node_modules(
-            jest_rule = _jest_binary,
+            jest_rule = jest_binary_rule,
             name = gen_snapshots_bin,
             node_modules = node_modules,
             config = config,

--- a/jest/private/jest_test.bzl
+++ b/jest/private/jest_test.bzl
@@ -166,3 +166,18 @@ lib = struct(
     attrs = _attrs,
     implementation = _impl,
 )
+
+jest_test = rule(
+    attrs = lib.attrs,
+    implementation = lib.implementation,
+    test = True,
+    toolchains = js_binary_lib.toolchains,
+)
+
+# binary rule used for snapshot updates
+jest_binary = rule(
+    attrs = lib.attrs,
+    implementation = lib.implementation,
+    executable = True,
+    toolchains = js_binary_lib.toolchains,
+)


### PR DESCRIPTION
Makes the macro less leaky abstraction, since bazel query still shows a jest_test.

**Type of change**

Refactor (a code change that neither fixes a bug or adds a new feature)

**Test plan**

How has this been tested?

Covered by existing test cases
