### PR TITLE
chore: remove bazeliskrc from e2e

### DIFF
--- a/e2e/smoke/.bazeliskrc
+++ b/e2e/smoke/.bazeliskrc
@@ -1,1 +1,0 @@
-../../.bazeliskrc


### PR DESCRIPTION
It fails on BCR presubmit
