### PR TITLE
chore: fix bzlmod windows presubmit

### DIFF
--- a/e2e/smoke/.bazelrc
+++ b/e2e/smoke/.bazelrc
@@ -1,1 +1,4 @@
-../../.bazelrc
+build --incompatible_strict_action_env
+build --nolegacy_external_runfiles
+# required for rules_js
+build --enable_runfiles


### PR DESCRIPTION
Windows bzlmod presubmit doesn't like bazelrc files via symlinks.

See https://github.com/bazelbuild/bazel-central-registry/pull/662 for failure.

---

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)
