### PR TITLE
chore: bump rules_js dep to 1.29.2 to pickup Windows fix

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,7 +1,7 @@
 bcr_test_module:
   module_path: "e2e/smoke"
   matrix:
-    platform: ["debian10", "macos", "ubuntu2004"]
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
   tasks:
     run_tests:
       name: "Run test module"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
 )
 
 bazel_dep(name = "aspect_bazel_lib", version = "1.32.1")
-bazel_dep(name = "aspect_rules_js", version = "1.27.0")
+bazel_dep(name = "aspect_rules_js", version = "1.29.2")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "rules_nodejs", version = "5.8.2")
 bazel_dep(name = "gazelle", version = "0.29.0", dev_dependency = True, repo_name = "bazel_gazelle")

--- a/e2e/npm_packages/MODULE.bazel
+++ b/e2e/npm_packages/MODULE.bazel
@@ -2,7 +2,7 @@
 
 bazel_dep(name = "aspect_bazel_lib", version = "1.32.1", dev_dependency = True)
 bazel_dep(name = "aspect_rules_jest", version = "0.0.0", dev_dependency = True)
-bazel_dep(name = "aspect_rules_js", version = "1.27.0", dev_dependency = True)
+bazel_dep(name = "aspect_rules_js", version = "1.29.2", dev_dependency = True)
 
 local_path_override(
     module_name = "aspect_rules_jest",

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -2,7 +2,7 @@
 
 bazel_dep(name = "aspect_bazel_lib", version = "1.32.1", dev_dependency = True)
 bazel_dep(name = "aspect_rules_jest", version = "0.0.0", dev_dependency = True)
-bazel_dep(name = "aspect_rules_js", version = "1.27.0", dev_dependency = True)
+bazel_dep(name = "aspect_rules_js", version = "1.29.2", dev_dependency = True)
 
 local_path_override(
     module_name = "aspect_rules_jest",

--- a/jest/dependencies.bzl
+++ b/jest/dependencies.bzl
@@ -18,9 +18,9 @@ def rules_jest_dependencies():
 
     http_archive(
         name = "aspect_rules_js",
-        sha256 = "d8827db3c34fe47607a0668e86524fd85d5bd74f2bfca93046d07f890b5ad4df",
-        strip_prefix = "rules_js-1.27.0",
-        url = "https://github.com/aspect-build/rules_js/releases/download/v1.27.0/rules_js-v1.27.0.tar.gz",
+        sha256 = "7cb2d84b7d5220194627c9a0267ae599e357350e75ea4f28f337a25ca6219b83",
+        strip_prefix = "rules_js-1.29.2",
+        url = "https://github.com/aspect-build/rules_js/releases/download/v1.29.2/rules_js-v1.29.2.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Windows fix. BCR should be green now for Windows with this change.

---

### Type of change

- Chore (any other change that doesn't affect source or test files, such as configuration)

### Test plan

- Covered by existing test cases
