### PR TITLE
Allow .ts files to be jest_test#config

### DIFF
--- a/jest/private/jest_test.bzl
+++ b/jest/private/jest_test.bzl
@@ -6,7 +6,13 @@ load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
 _attrs = dicts.add(js_binary_lib.attrs, {
-    "config": attr.label(allow_single_file = [".js", ".cjs", ".mjs", ".json"]),
+    "config": attr.label(allow_single_file = [
+        ".js",
+        ".cjs",
+        ".mjs",
+        ".json",
+        ".ts",  # jest permits this if it resolves ts-node in its dependencies
+    ]),
     "auto_configure_reporters": attr.bool(default = True),
     "auto_configure_test_sequencer": attr.bool(default = True),
     "run_in_band": attr.bool(default = True),


### PR DESCRIPTION

### Type of change

- Bug fix (change which fixes an issue)

- Suggested release notes are provided below:
config files may now be in TypeScript. Be sure jest can find ts-node in its dependencies.

### Test plan

None - hoping users will confirm