### PR TITLE
fix: windows file URL issue

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,28 @@
+# Bazel settings that apply to this repository.
+# Take care to document any settings that you expect users to apply.
+# Settings that apply only to CI are in .github/workflows/ci.bazelrc
+
+# Bazel picks up host-OS-specific config lines from bazelrc files. For example, if the host OS is
+# Linux and you run bazel build, Bazel picks up lines starting with build:linux. Supported OS
+# identifiers are `linux`, `macos`, `windows`, `freebsd`, and `openbsd`. Enabling this flag is
+# equivalent to using `--config=linux` on Linux, `--config=windows` on Windows, etc.
+# Docs: https://bazel.build/reference/command-line-reference#flag--enable_platform_specific_config
+common --enable_platform_specific_config
+
+# Required by rules_js
+build --enable_runfiles
+
 build --incompatible_strict_action_env
 build --nolegacy_external_runfiles
-# required for rules_js
-build --enable_runfiles
+
+# Filter out tests depending on platform
+test:windows --test_tag_filters=-no-windows
+
+# Load any settings specific to the current user.
+# .bazelrc.user should appear in .gitignore so that settings are not shared with team members
+# This needs to be last statement in this
+# config, as the user configuration should be able to overwrite flags from this file.
+# See https://docs.bazel.build/versions/master/best-practices.html#bazelrc
+# (Note that we use .bazelrc.user so the file appears next to .bazelrc in directory listing,
+# rather than user.bazelrc as suggested in the Bazel docs)
+try-import %workspace%/.bazelrc.user

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,14 @@ jobs:
     uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v2
     with:
       folders: '[".", "e2e/npm_packages", "e2e/smoke"]'
-
+      exclude: |
+        [
+          {"bazelversion": "5.4.0", "bzlmodEnabled": true},
+          {"bazelversion": "5.4.0", "os": "macos-latest"},
+          {"bazelversion": "5.4.0", "os": "windows-latest"},
+          {"folder": ".", "os": "windows-latest"},
+          {"folder": "e2e/npm_packages", "os": "windows-latest"},
+        ]
   test-e2e:
     runs-on: ubuntu-latest
     steps:

--- a/e2e/smoke/BUILD.bazel
+++ b/e2e/smoke/BUILD.bazel
@@ -8,4 +8,18 @@ jest_test(
     config = "jest.config.js",
     data = ["index.test.js"],
     node_modules = "//:node_modules",
+    # jest does not find tests on Windows; it appears the fix in https://github.com/jestjs/jest/pull/9351
+    # for discovering tests when they are symlinks does not work on Windows.
+    tags = ["no-windows"],
+)
+
+jest_test(
+    name = "by_path_test",
+    args = [
+        "--runTestsByPath",
+        "index.test.js",
+    ],
+    config = "jest.config.js",
+    data = ["index.test.js"],
+    node_modules = "//:node_modules",
 )

--- a/jest/private/jest_config_template.mjs
+++ b/jest/private/jest_config_template.mjs
@@ -65,14 +65,18 @@ function _addReporter(config, name, reporter = undefined) {
 let config = {};
 if (userConfigShortPath) {
   if (path.extname(userConfigShortPath).toLowerCase() == ".json") {
+    // On Windows, import does not like paths that start with the drive letter such as
+    // `c:\...` so we prepend the with `file://` so node is happy.
     config = (
-      await import(_resolveRunfilesPath(userConfigShortPath), {
+      await import("file://" + _resolveRunfilesPath(userConfigShortPath), {
         assert: { type: "json" },
       })
     ).default;
   } else {
+    // On Windows, import does not like paths that start with the drive letter such as
+    // `c:\...` so we prepend the with `file://` so node is happy.
     const userConfigModule = (
-      await import(_resolveRunfilesPath(userConfigShortPath))
+      await import("file://" + _resolveRunfilesPath(userConfigShortPath))
     ).default;
     if (typeof userConfigModule === "function") {
       config = await userConfigModule();


### PR DESCRIPTION
Limiting Windows CI to just e2e/smoke which is tested by the BCR pre-submit since jest on Windows does not auto-discover tests due to the old symlinks issue. The upstream fix to enable symlinks in jest-haste-map appears to not have worked on Windows.

---

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Covered by existing test cases
