### PR TITLE
chore: bump CI workflows template to v3 which has the exclude attribute

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   test:
-    uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v2
+    uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v3
     with:
       folders: '[".", "e2e/npm_packages", "e2e/smoke"]'
       exclude: |

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -3,6 +3,7 @@
 bazel_dep(name = "aspect_bazel_lib", version = "1.32.1", dev_dependency = True)
 bazel_dep(name = "aspect_rules_jest", version = "0.0.0", dev_dependency = True)
 bazel_dep(name = "aspect_rules_js", version = "1.29.2", dev_dependency = True)
+bazel_dep(name = "platforms", version = "0.0.4")
 
 local_path_override(
     module_name = "aspect_rules_jest",


### PR DESCRIPTION
`exclude` added in v3: https://github.com/bazel-contrib/.github/commit/f4ef92734cbf2580f7ef53df92aa0281a4d82220