### PR TITLE
Add quotes around config path

### DIFF
--- a/example/(simple_group)/BUILD.bazel
+++ b/example/(simple_group)/BUILD.bazel
@@ -1,0 +1,100 @@
+load("@aspect_rules_jest//jest:defs.bzl", "jest_test")
+
+jest_test(
+    name = "test",
+    data = [
+        "index.js",
+        "index.test.js",
+    ],
+    node_modules = "//:node_modules",
+)
+
+jest_test(
+    name = "test_user_data",
+    data = [
+        "index.js",
+        "index.test.js",
+        # should be able to add jest-cli & jest-junit explicitly in data
+        "//:node_modules/jest-cli",
+        "//:node_modules/jest-junit",
+    ],
+    node_modules = "//:node_modules",
+)
+
+jest_test(
+    name = "js_config_test",
+    config = "jest.config.js",
+    data = [
+        "index.js",
+        "index.test.js",
+    ],
+    node_modules = "//:node_modules",
+)
+
+jest_test(
+    name = "cjs_config_test",
+    config = "jest.config.cjs",
+    data = [
+        "index.js",
+        "index.test.js",
+    ],
+    node_modules = "//:node_modules",
+)
+
+jest_test(
+    name = "mjs_config_test",
+    config = "jest.config.mjs",
+    data = [
+        "index.js",
+        "index.test.js",
+    ],
+    node_modules = "//:node_modules",
+)
+
+jest_test(
+    name = "json_config_test",
+    config = "jest.config.json",
+    data = [
+        "index.js",
+        "index.test.js",
+    ],
+    node_modules = "//:node_modules",
+)
+
+jest_test(
+    name = "gen_config_test",
+    config = "gen.config.json",
+    data = [
+        "index.js",
+        "index.test.js",
+    ],
+    node_modules = "//:node_modules",
+)
+
+genrule(
+    name = "gen_config",
+    testonly = True,
+    srcs = ["jest.config.json"],
+    outs = ["gen.config.json"],
+    cmd = "cp $(location :jest.config.json) \"$@\"",
+)
+
+jest_test(
+    name = "target_config_test",
+    config = ":gen_config",
+    data = [
+        "index.js",
+        "index.test.js",
+    ],
+    node_modules = "//:node_modules",
+)
+
+jest_test(
+    name = "other_target_config_test",
+    config = "//jest/tests/configs:basic",
+    data = [
+        "index.js",
+        "index.test.js",
+    ],
+    node_modules = "//:node_modules",
+)

--- a/example/(simple_group)/index.js
+++ b/example/(simple_group)/index.js
@@ -1,0 +1,1 @@
+module.exports = "test";

--- a/example/(simple_group)/index.test.js
+++ b/example/(simple_group)/index.test.js
@@ -1,0 +1,5 @@
+const index = require(".");
+
+test("it should work", () => {
+  expect(index).toBe("test");
+});

--- a/example/(simple_group)/jest.config.cjs
+++ b/example/(simple_group)/jest.config.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: "node",
+  testMatch: ["**/*.test.js"],
+};

--- a/example/(simple_group)/jest.config.js
+++ b/example/(simple_group)/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: "node",
+  testMatch: ["**/*.test.js"],
+};

--- a/example/(simple_group)/jest.config.json
+++ b/example/(simple_group)/jest.config.json
@@ -1,0 +1,4 @@
+{
+  "testEnvironment": "node",
+  "testMatch": ["**/*.test.js"]
+}

--- a/example/(simple_group)/jest.config.mjs
+++ b/example/(simple_group)/jest.config.mjs
@@ -1,0 +1,4 @@
+export default {
+  testEnvironment: "node",
+  testMatch: ["**/*.test.js"],
+};

--- a/jest/private/jest_test.bzl
+++ b/jest/private/jest_test.bzl
@@ -82,7 +82,7 @@ def _impl(ctx):
         # https://jestjs.io/docs/cli#--configpath. The path to a Jest config file specifying how to
         # find and execute tests.
         "--config",
-        paths.join(unwind_chdir_prefix, generated_config.short_path),
+        "\"" + paths.join(unwind_chdir_prefix, generated_config.short_path) + "\"",
     ])
     if ctx.attr.log_level == "debug":
         fixed_args.append("--debug")

--- a/jest/private/jest_test.bzl
+++ b/jest/private/jest_test.bzl
@@ -82,7 +82,9 @@ def _impl(ctx):
         # https://jestjs.io/docs/cli#--configpath. The path to a Jest config file specifying how to
         # find and execute tests.
         "--config",
-        "\"" + paths.join(unwind_chdir_prefix, generated_config.short_path) + "\"",
+        # quote the path since it might have special chars such as parens.
+        # quoting ensures that the shell doesn't do any globbing or splitting.
+        "'" + paths.join(unwind_chdir_prefix, generated_config.short_path) + "'",
     ])
     if ctx.attr.log_level == "debug":
         fixed_args.append("--debug")


### PR DESCRIPTION
I can't tell if this is actually a good fix, let me know!

### Type of change

- Bug fix (change which fixes an issue): https://github.com/aspect-build/rules_jest/issues/151

### Test plan

- New test cases added: I copied the `simple/` folder to `(simple_group)/` to ensure all the different types of configs pass.
