### PR TITLE
chore: update README so it slurps to docs.aspect.build

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ copy the WORKSPACE snippet into your `WORKSPACE` file.
 
 Run all Jest tests in the workspace: `bazel test --test_lang_filters=jest //...`
 
-See the documentation in the [docs](docs/) folder and the example usages in the [example](example/) folder.
+See [jest_test](docs/jest_test) API documentation and the example usages in the [example](https://github.com/aspect-build/rules_jest/tree/main/example/) folder.
 
 > Note that the example also relies on code in the `/WORKSPACE` file in the root of this repo.


### PR DESCRIPTION
Otherwise the example link is broken.

---

### Type of change

- Documentation (updates to documentation or READMEs)

### Test plan

This now matches the manual edit we've been making while slurping docs.