### PR TITLE
fix: Quote the config path to allow special chars

### DIFF
--- a/jest/private/jest_test.bzl
+++ b/jest/private/jest_test.bzl
@@ -84,7 +84,7 @@ def _impl(ctx):
         "--config",
         # quote the path since it might have special chars such as parens.
         # quoting ensures that the shell doesn't do any globbing or splitting.
-        '"' + paths.join(unwind_chdir_prefix, generated_config.short_path) + '"',
+        "'" + paths.join(unwind_chdir_prefix, generated_config.short_path) + "'",
     ])
     if ctx.attr.log_level == "debug":
         fixed_args.append("--debug")

--- a/jest/private/jest_test.bzl
+++ b/jest/private/jest_test.bzl
@@ -82,7 +82,9 @@ def _impl(ctx):
         # https://jestjs.io/docs/cli#--configpath. The path to a Jest config file specifying how to
         # find and execute tests.
         "--config",
-        paths.join(unwind_chdir_prefix, generated_config.short_path),
+        # quote the path since it might have special chars such as parens.
+        # quoting ensures that the shell doesn't do any globbing or splitting.
+        '"' + paths.join(unwind_chdir_prefix, generated_config.short_path) + '"',
     ])
     if ctx.attr.log_level == "debug":
         fixed_args.append("--debug")


### PR DESCRIPTION
### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Manual testing; please provide instructions so we can reproduce:

Create a jest test rule in a folder that has parens in it's name. (This is a pattern used by nextjs for [route groups](https://nextjs.org/docs/app/building-your-application/routing/route-groups))
Run that test. It would fail before this patch, it now passes.
