### PR TITLE
feat: default cacheDirectory to TEST_TMPDIR

### DIFF
--- a/e2e/case13.sh
+++ b/e2e/case13.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
+
+# Jest default is os.tmpdir()/jest_<uid>
+TEST_TMPDIR=$(mktemp -d)/jest_test_tmpdir
+
+# Case 13: jest_test uses TEST_TMPDIR
+rm -rf $TEST_TMPDIR
+bazel test //jest/tests:case13 --nocache_test_results --test_tmpdir=$TEST_TMPDIR
+
+# Check if TEST_TMPDIR was utilized by the test action
+if [ ! -d "$TEST_TMPDIR" ] || [ -z "$(ls -A "$TEST_TMPDIR")" ]; then
+  echo "Error: test_tmpdir '$TEST_TMPDIR' does not exist or is empty"
+  exit 1
+fi

--- a/e2e/case13.sh
+++ b/e2e/case13.sh
@@ -5,11 +5,21 @@ set -o errexit -o nounset -o pipefail
 TEST_TMPDIR=$(mktemp -d)/jest_test_tmpdir
 
 # Case 13: jest_test uses TEST_TMPDIR
-rm -rf $TEST_TMPDIR
+rm -rf "$TEST_TMPDIR"
 bazel test //jest/tests:case13 --nocache_test_results --test_tmpdir=$TEST_TMPDIR
 
-# Check if TEST_TMPDIR was utilized by the test action
-if [ ! -d "$TEST_TMPDIR" ] || [ -z "$(ls -A "$TEST_TMPDIR")" ]; then
-  echo "Error: test_tmpdir '$TEST_TMPDIR' does not exist or is empty"
+# Locate the cache folder under TEST_TMPDIR
+JEST_CACHE_NAME="jest_cache"
+JEST_CACHE_DIR=$(find "$TEST_TMPDIR" -type d -name "$JEST_CACHE_NAME" -print -quit)
+
+# Check that the cache folder exists
+if [ -z "$JEST_CACHE_DIR" ]; then
+  echo "Error: '$JEST_CACHE_NAME' folder not found below '$TEST_TMPDIR'"
+  exit 1
+fi
+
+# Check that the folder was used for the cache
+if [ -z "$(ls -A "$JEST_CACHE_DIR")" ]; then
+  echo "Error: '$JEST_CACHE_NAME' folder at '$JEST_CACHE_DIR' is empty"
   exit 1
 fi

--- a/jest/private/jest_config_template.mjs
+++ b/jest/private/jest_config_template.mjs
@@ -86,6 +86,9 @@ if (userConfigShortPath) {
   }
 }
 
+// Default to using an isolated tmpdir
+config.cacheDirectory ||= process.env.TEST_TMPDIR;
+
 // Needed for Jest to walk the filesystem to find inputs.
 // See https://github.com/facebook/jest/pull/9351
 config.haste = { enableSymlinks: true };

--- a/jest/private/jest_config_template.mjs
+++ b/jest/private/jest_config_template.mjs
@@ -87,7 +87,8 @@ if (userConfigShortPath) {
 }
 
 // Default to using an isolated tmpdir
-config.cacheDirectory ||= process.env.TEST_TMPDIR;
+config.cacheDirectory ||= path.join(process.env.TEST_TMPDIR, 'jest_cache');
+
 
 // Needed for Jest to walk the filesystem to find inputs.
 // See https://github.com/facebook/jest/pull/9351

--- a/jest/tests/BUILD.bazel
+++ b/jest/tests/BUILD.bazel
@@ -165,12 +165,22 @@ jest_test(
     node_modules = "//:node_modules",
 )
 
-# Case 11: Coverage reporting (see e2e test)
+# Case 12: Coverage reporting (see e2e test)
 jest_test(
     name = "case12",
     data = [
         "case12.index.js",
         "case12.test.js",
+    ],
+    node_modules = "//:node_modules",
+)
+
+# Case 13: jest_test uses TEST_TMPDIR (see e2e test)
+jest_test(
+    name = "case13",
+    config = "case13.jest.config.js",
+    data = [
+        "case13.test.js",
     ],
     node_modules = "//:node_modules",
 )

--- a/jest/tests/case13.jest.config.js
+++ b/jest/tests/case13.jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  reporters: ["default"],
+  testEnvironment: "node",
+  testMatch: ["**/*.test.js"],
+};

--- a/jest/tests/case13.test.js
+++ b/jest/tests/case13.test.js
@@ -1,0 +1,3 @@
+test("it should work", () => {
+  expect(1).toBe(1);
+});


### PR DESCRIPTION
See https://github.com/aspect-build/rules_jest/issues/230

---

<!-- Delete this comment! Follow our PR template instructions: https://github.com/aspect-build/.github/blob/main/pull_requests.md -->

### Type of change

- New feature or functionality (change which adds functionality)

**For changes visible to end-users**

- Suggested release notes are provided below:

Now cacheDirector is set to TEST_TMPDIR by default to improve test isolation and cleanup. 

### Test plan

- This change is foundational and affects every test in the codebase. Existing tests confirm this doesn't introduce a regression.
- It doesn't appear to be possible to determine the cacheDirectory from within a jest test suite. However, an e2e test is added that explicitly sets --test_tmpdir and confirms that jest produced outputs in that folder indicating that it was successfully passed through the config chain.
- The case where user configuration specifies cacheDirectory via config is currently untested. It is unclear if that should even be allowed since --no-cache is forced and the location of the --cacheDirectory is otherwise an implementation detail of the rules.
