### PR TITLE
chore: add example of using Aspect Workflows task hooks

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -8,6 +8,15 @@ tasks:
   - gazelle:
   - configure:
   - test:
+      hooks:
+        # Example of asserting that `bazel query //...` is green in a before_task hook.
+        # Flags set:
+        # - --nohome_rc prevents using a ~/.bazelrc file incase one gets created on the runner unintentionally by a rogue job
+        # - --bazelrc=.aspect/workflows/bazelrc keeps the bazel flags on the bazel query call consistent with what Workflows uses for bazel test
+        # - --aspect:lock_version use the Aspect CLI version matching the Workflows version
+        # - --config=workflows set all Workflows configuration flags; these are defined in /etc/bazel.bazelrc
+        - type: before_task
+          command: bazel --nohome_rc --bazelrc=.aspect/workflows/bazelrc query --aspect:lock_version --config=workflows //...
       coverage: true
       upload_test_logs: executed
       queue: aspect-default


### PR DESCRIPTION
An example of making a `bazel query //...` call in the before_task hook so the build asserts that invariant is green.

Some minimal flags are required:

startup flags:
- `--nohome_rc` (ignore any `~/.bazelrc` incase one gets created on the runner unintentionally by a rogue job; this flag could we could set in `/etc/bazel.bazelrc` in the future)
- `--bazelrc=.aspect/workflows/bazelrc` (if this file exists, which it does in this repo, this keeps the bazel flags on the `bazel query` call consistent with what Workflows uses for `bazel test`)

regular flags:
- `--aspect:lock_version` (ensure the version of the Aspect CLI used matches the Workflows version and the one used in bazel test incase there happens to be another version configured in `.bazeliskrc`)
- `--config=workflows` (picks up all the Workflows flags from `/etc/bazel.bazelrc`)