### PR TITLE
chore: remove gofmt

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -28,7 +28,6 @@ alias(
 
 multi_formatter_binary(
     name = "format",
-    go = "@go_sdk//:bin/gofmt",
     sh = ":shfmt",
     starlark = "@buildifier_prebuilt//:buildifier",
     terraform = ":terraform",


### PR DESCRIPTION
We don't have any Go source files so there's no point configuring a formatter.

---