### PR TITLE
snapshots: only create `*_update_snapshots` target upon request

### DIFF
--- a/jest/defs.bzl
+++ b/jest/defs.bzl
@@ -240,24 +240,25 @@ def jest_test(
         **kwargs
     )
 
-    _jest_from_node_modules(
-        jest_rule = jest_test_rule,
-        name = name + UPDATE_SNAPSHOTS_TARGET_SUFFIX,
-        node_modules = node_modules,
-        config = config,
-        # Also pass data to the tool for jest snapshot updates incase there are load bearing
-        # data deps the config requires
-        data = data,
-        run_in_band = run_in_band,
-        colors = colors,
-        auto_configure_reporters = auto_configure_reporters,
-        auto_configure_test_sequencer = auto_configure_test_sequencer,
-        update_snapshots = True,
-        quiet_snapshot_updates = quiet_snapshot_updates,
-        entry_point = entry_point,
-        bazel_sequencer = bazel_sequencer,
-        bazel_snapshot_reporter = bazel_snapshot_reporter,
-        bazel_snapshot_resolver = bazel_snapshot_resolver,
-        tags = tags + ["manual"],  # tagged manual so it is not built unless the {name}_update_snapshot target is run
-        **kwargs
-    )
+    if snapshots != False:
+        _jest_from_node_modules(
+            jest_rule = jest_test_rule,
+            name = name + UPDATE_SNAPSHOTS_TARGET_SUFFIX,
+            node_modules = node_modules,
+            config = config,
+            # Also pass data to the tool for jest snapshot updates incase there are load bearing
+            # data deps the config requires
+            data = data,
+            run_in_band = run_in_band,
+            colors = colors,
+            auto_configure_reporters = auto_configure_reporters,
+            auto_configure_test_sequencer = auto_configure_test_sequencer,
+            update_snapshots = True,
+            quiet_snapshot_updates = quiet_snapshot_updates,
+            entry_point = entry_point,
+            bazel_sequencer = bazel_sequencer,
+            bazel_snapshot_reporter = bazel_snapshot_reporter,
+            bazel_snapshot_resolver = bazel_snapshot_resolver,
+            tags = tags + ["manual"],  # tagged manual so it is not built unless the {name}_update_snapshot target is run
+            **kwargs
+        )


### PR DESCRIPTION
Currently everyone gets this target even if `snapshots` was left empty. This causes extra execution for folks who use CI to run all changed targets. It's preferable not to have a duplicate target like this.

---

### Type of change

- Bug fix (change which fixes an issue)

**For changes visible to end-users**

- Relevant documentation already implies this change
- Suggested release notes are provided below:

Only generate `*_update_snapshots` targets upon request

### Test plan

- Covered by existing test cases
