### PR TITLE
fix: refactor case10 and case10a tests so they don't have duplicate outputs

### DIFF
--- a/.aspect/cli/config.yaml
+++ b/.aspect/cli/config.yaml
@@ -2,5 +2,5 @@ configure:
   languages:
     javascript: true
     go: true
-    kotlin: true
+    kotlin: false
     protobuf: true

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -8,7 +8,11 @@ stardoc_with_diff_test(
     symbol_names = ["jest_test"],
 )
 
-update_docs(name = "update")
+update_docs(
+    name = "update",
+    # slight docs difference in Bazel 6
+    tags = ["skip-on-bazel6"],
+)
 
 # Demonstration delivery target for Aspect Workflows.
 # In the future this could be wired up to push to a demonstration S3 bucket.

--- a/e2e/update_snapshots_test.sh
+++ b/e2e/update_snapshots_test.sh
@@ -36,7 +36,7 @@ update_snapshot_e2e_test example/snapshots_files/__snapshots__/link.test.js.snap
 update_snapshot_e2e_test example/custom_snapshot_resolver/__my_snapshots__/link.test.js.snap //example/custom_snapshot_resolver:test
 update_snapshot_e2e_test example/custom_snapshot_resolver_files/link.test.js.snap //example/custom_snapshot_resolver_files:test
 update_snapshot_e2e_test jest/tests/package_json_module/__snapshots__/link.test.js.snap //jest/tests/package_json_module:test
-update_snapshot_e2e_test jest/tests/case10/__snapshots__/case10.test.js.snap //jest/tests:case10
-update_snapshot_e2e_test jest/tests/case10/__snapshots__/case10.test.js.snap //jest/tests:case10a
+update_snapshot_e2e_test jest/tests/case10/__snapshots__/case10.test.js.snap //jest/tests/case10:test
+update_snapshot_e2e_test jest/tests/case10a/__snapshots__/case10a.test.js.snap //jest/tests/case10a:test
 
 echo "All tests passed"

--- a/example/multiple_snapshots/BUILD.bazel
+++ b/example/multiple_snapshots/BUILD.bazel
@@ -47,7 +47,7 @@ js_library(
     ],
 )
 
-# TEST: Ensure the {name}_update_snapshots target builds successfully
+# TEST: Ensure the :test_update_snapshots target exists and builds successfully
 build_test(
     name = "update_snapshots_build",
     targets = [":test_update_snapshots"],

--- a/example/snapshots/BUILD.bazel
+++ b/example/snapshots/BUILD.bazel
@@ -51,7 +51,7 @@ js_library(
     ],
 )
 
-# TEST: Ensure the {name}_update_snapshots target builds successfully
+# TEST: Ensure the :test_update_snapshots target exists and builds successfully
 build_test(
     name = "update_snapshots_build",
     targets = [":test_update_snapshots"],

--- a/jest/tests/BUILD.bazel
+++ b/jest/tests/BUILD.bazel
@@ -1,5 +1,3 @@
-load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//jest:defs.bzl", "jest_test")
 
@@ -102,47 +100,6 @@ jest_test(
     node_options = [
         "--experimental-vm-modules",
     ],
-)
-
-# Case 10: A js_library() config specifying test-time dependencies
-jest_test(
-    name = "case10",
-    config = ":case10-config",
-    data = [
-        "case10/case10.test.js",
-    ],
-    node_modules = "//:node_modules",
-    snapshots = True,
-)
-
-# Case 10a: case10 with the chdir param to try a different cwd
-jest_test(
-    name = "case10a",
-    chdir = package_name(),
-    config = ":case10-config",
-    data = [
-        "case10/case10.test.js",
-    ],
-    node_modules = "//:node_modules",
-    snapshots = True,
-)
-
-js_library(
-    name = "case10-config",
-    srcs = [
-        "case10/case10.jest.config.js",
-    ],
-    data = [
-        "case10/case10.config-init.js",
-        "case10/case10.setup.js",
-        ":node_modules/@aspect-test/c",
-    ],
-)
-
-# Ensure the case10 snapshot target exists
-build_test(
-    name = "case10-update_snapshots_build",
-    targets = [":case10_update_snapshots"],
 )
 
 # Case 11a: jest config file producing config as function

--- a/jest/tests/case10/BUILD.bazel
+++ b/jest/tests/case10/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("//jest:defs.bzl", "jest_test")
+
+# Case 10: A js_library() config specifying test-time dependencies
+jest_test(
+    name = "test",
+    config = ":case10-config",
+    data = [
+        "case10.test.js",
+    ],
+    node_modules = "//:node_modules",
+    snapshots = True,
+)
+
+js_library(
+    name = "case10-config",
+    srcs = [
+        "case10.jest.config.js",
+    ],
+    data = [
+        "case10.config-init.js",
+        "case10.setup.js",
+        "//jest/tests:node_modules/@aspect-test/c",
+    ],
+)
+
+# TEST: Ensure the :test_update_snapshots target exists and builds successfully
+build_test(
+    name = "cupdate_snapshots_build",
+    targets = [":test_update_snapshots"],
+)

--- a/jest/tests/case10a/BUILD.bazel
+++ b/jest/tests/case10a/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("//jest:defs.bzl", "jest_test")
+
+# Case 10a: case10 with the chdir param to try a different cwd
+jest_test(
+    name = "test",
+    chdir = package_name(),
+    config = ":case10a-config",
+    data = [
+        "case10a.test.js",
+    ],
+    node_modules = "//:node_modules",
+    snapshots = True,
+)
+
+js_library(
+    name = "case10a-config",
+    srcs = [
+        "case10a.jest.config.js",
+    ],
+    data = [
+        "case10a.config-init.js",
+        "case10a.setup.js",
+        "//jest/tests:node_modules/@aspect-test/c",
+    ],
+)
+
+# TEST: Ensure the :test_update_snapshots target exists and builds successfully
+build_test(
+    name = "update_snapshots_build",
+    targets = [":test_update_snapshots"],
+)

--- a/jest/tests/case10a/__snapshots__/case10a.test.js.snap
+++ b/jest/tests/case10a/__snapshots__/case10a.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`the config + setup files run 1`] = `42`;
+
+exports[`the config + setup files run 2`] = `true`;
+
+exports[`the config + setup files run 3`] = `true`;

--- a/jest/tests/case10a/case10a.config-init.js
+++ b/jest/tests/case10a/case10a.config-init.js
@@ -1,0 +1,1 @@
+global.TEST_CONFIG_INIT_VALUE = true;

--- a/jest/tests/case10a/case10a.jest.config.js
+++ b/jest/tests/case10a/case10a.jest.config.js
@@ -1,0 +1,12 @@
+const path = require("path");
+
+// A config-time file dep
+require("./case10a.config-init");
+
+// A config-time npm dep and config-time value to verify
+global.TEST_CONFIG_VALUE = typeof require("@aspect-test/c").id === "function";
+
+module.exports = {
+  // A runtime setup dep
+  setupFiles: [path.join(__dirname, "case10a.setup.js")],
+};

--- a/jest/tests/case10a/case10a.setup.js
+++ b/jest/tests/case10a/case10a.setup.js
@@ -1,0 +1,1 @@
+global.TEST_SETUP_VALUE = 42;

--- a/jest/tests/case10a/case10a.test.js
+++ b/jest/tests/case10a/case10a.test.js
@@ -1,0 +1,10 @@
+test("the config + setup files run", () => {
+  expect(TEST_SETUP_VALUE).toEqual(42);
+  expect(TEST_SETUP_VALUE).toMatchSnapshot();
+
+  expect(TEST_CONFIG_VALUE).toBe(true);
+  expect(TEST_CONFIG_VALUE).toMatchSnapshot();
+
+  expect(TEST_CONFIG_INIT_VALUE).toBe(true);
+  expect(TEST_CONFIG_INIT_VALUE).toMatchSnapshot();
+});

--- a/jest/tests/package_json_module/BUILD.bazel
+++ b/jest/tests/package_json_module/BUILD.bazel
@@ -44,7 +44,7 @@ js_library(
     ],
 )
 
-# TEST: Ensure the {name}_update_snapshots target builds successfully
+# TEST: Ensure the :test_update_snapshots target exists and builds successfully
 build_test(
     name = "update_snapshots_build",
     targets = [":test_update_snapshots"],


### PR DESCRIPTION
Pre-factor from https://github.com/aspect-build/rules_jest/pull/269.

Fixes build issue:

```
(17:42:17) ERROR: One of the output paths 'bazel-out/k8-fastbuild/bin/jest/tests/case10' (belonging to //jest/tests:case10) and 'bazel-out/k8-fastbuild/bin/jest/tests/case10/case10.test.js' (belonging to //jest/tests:case10_update_snapshots) is a prefix of the other. These actions cannot be simultaneously present; please rename one of the output files or build just one of them
(17:42:17) ERROR: One of the output paths 'bazel-out/k8-fastbuild/bin/jest/tests/case10' (belonging to //jest/tests:case10) and 'bazel-out/k8-fastbuild/bin/jest/tests/case10/__snapshots__/case10.test.js.snap' (belonging to //jest/tests:case10a) is a prefix of the other. These actions cannot be simultaneously present; please rename one of the output files or build just one of them
```