### PR TITLE
Merge haste configs if they are available

### DIFF
--- a/jest/private/jest_config_template.mjs
+++ b/jest/private/jest_config_template.mjs
@@ -92,7 +92,7 @@ config.cacheDirectory ||= path.join(process.env.TEST_TMPDIR, 'jest_cache');
 
 // Needed for Jest to walk the filesystem to find inputs.
 // See https://github.com/facebook/jest/pull/9351
-config.haste = { enableSymlinks: true };
+config.haste = { enableSymlinks: true, ...config.haste };
 
 // https://jestjs.io/docs/cli#--watchman. Whether to use watchman for file crawling. Defaults
 // to true. Disable using --no-watchman. Watching is ibazel's job


### PR DESCRIPTION
Per Slack discussion:

> In `rules_jest`, is "_jest_config_template" meant to be configurable?
> 
> (why? `config.haste = { enableSymlinks: true }` is conflicting with React-native preset's haste: `{ defaultPlatform: 'ios', platforms: […], }` configuration)

@gregmagolan told _me_ to "go do it yourself!" (not his words)

> The fix would be to merge the two together. Would be happy to accept a PR for that.

👍 

---

### Changes are visible to end-users: no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

`jest_test` will now preserve your `jest.config.js` settings.

```python
jest_test(
  …
  config = "jest.config.js",  # previously, `haste` configuration in this file would be overridden
)
```

### Test plan

- ~~Covered by existing test cases~~
- New test cases added (jest/test/case14*)
- Manual testing; please provide instructions so we can reproduce:

Add `haste` configuration to `jest.config.js`, watch it get merged into the defaults `{ enableSymlinks: true }` defined in *jest_config_template.mjs*