### PR TITLE
chore: bump minimum rules_nodejs to 6.2.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@ module(
 bazel_dep(name = "aspect_bazel_lib", version = "2.7.7")
 bazel_dep(name = "aspect_rules_js", version = "2.0.0-rc1")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
-bazel_dep(name = "rules_nodejs", version = "6.1.0")
+bazel_dep(name = "rules_nodejs", version = "6.2.0")
 
 ####### Dev dependencies ########
 

--- a/jest/dependencies.bzl
+++ b/jest/dependencies.bzl
@@ -26,9 +26,9 @@ def rules_jest_dependencies():
 
     http_archive(
         name = "rules_nodejs",
-        sha256 = "dddd60acc3f2f30359bef502c9d788f67e33814b0ddd99aa27c5a15eb7a41b8c",
-        strip_prefix = "rules_nodejs-6.1.0",
-        url = "https://github.com/bazelbuild/rules_nodejs/releases/download/v6.1.0/rules_nodejs-v6.1.0.tar.gz",
+        sha256 = "87c6171c5be7b69538d4695d9ded29ae2626c5ed76a9adeedce37b63c73bef67",
+        strip_prefix = "rules_nodejs-6.2.0",
+        url = "https://github.com/bazelbuild/rules_nodejs/releases/download/v6.2.0/rules_nodejs-v6.2.0.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
Ensures users pick up https://github.com/bazelbuild/rules_nodejs/pull/3760 fix which is a footgun that should be avoided.