### PR TITLE
fix: use of the bazel supplied list of runfiles by jest subprocesses

### DIFF
--- a/jest/private/bazel_haste_map.cjs
+++ b/jest/private/bazel_haste_map.cjs
@@ -18,10 +18,7 @@ const WORKSPACE_RUNFILES = join(
   process.env.TEST_SRCDIR,
   process.env.TEST_WORKSPACE,
 );
-const BAZEL_FILELIST_JSON_FULL_PATH = join(
-  WORKSPACE_RUNFILES,
-  global.BAZEL_FILELIST_JSON_SHORT_PATH,
-);
+const BAZEL_FILELIST_JSON_FULL_PATH = process.env.BAZEL_FILELIST_JSON_FULL_PATH;
 
 /**
  * Extend the standard jest HasteMap to use rules_jest

--- a/jest/private/jest_config_template.mjs
+++ b/jest/private/jest_config_template.mjs
@@ -21,6 +21,13 @@ const bazelSnapshotResolverPath = _resolveRunfilesPath(
 const bazelHasteMapModulePath = _resolveRunfilesPath(
   "{{BAZEL_HASTE_MAP_MODULE_SHORT_PATH}}",
 );
+const bazelFilelistJsonPath = _resolveRunfilesPath(
+  "{{BAZEL_FILELIST_JSON_SHORT_PATH}}",
+);
+
+// Store the filelist as an envvar that will be accessible to bazel_haste_map.cjs, including
+// from potential jest launched child processes.
+process.env.BAZEL_FILELIST_JSON_FULL_PATH = bazelFilelistJsonPath;
 
 if (
   !updateSnapshots &&
@@ -100,9 +107,6 @@ if (userConfigShortPath) {
 }
 
 _verifyJestConfig(config);
-
-// Templated config that must be persisted globally for use by other rules_jest bazel_*.cjs files.
-global.BAZEL_FILELIST_JSON_SHORT_PATH = "{{BAZEL_FILELIST_JSON_SHORT_PATH}}";
 
 // Default to using an isolated tmpdir
 config.cacheDirectory ||= path.join(process.env.TEST_TMPDIR, "jest_cache");


### PR DESCRIPTION
Use an env var instead of global so any child processes that jest launches will have access.

---

### Changes are visible to end-users: no

### Test plan

- Manual testing; run on a large repo when `run_in_band = False`
