### PR TITLE
Add `auto_configure_reporting` attribute to allow end users to eject from default behavior

### DIFF
--- a/jest/private/jest_config_template.mjs
+++ b/jest/private/jest_config_template.mjs
@@ -201,7 +201,7 @@ if (coverageEnabled) {
    * can integrate their own coverage reporters.
    * Note, if a user does this, they are also responsible for the split coverage processing logic
    */
-  if (autoConfReporting === "1") {
+  if (autoConfReporting) {
     if (process.env.SPLIT_COVERAGE_POST_PROCESSING == "1") {
       // in split coverage post processing mode bazel assumes that the COVERAGE_OUTPUT_FILE
       // will be created by lcov_merger which runs as a separate action with everything in

--- a/jest/private/jest_test.bzl
+++ b/jest/private/jest_test.bzl
@@ -7,6 +7,7 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 
 _attrs = dicts.add(js_binary_lib.attrs, {
     "config": attr.label(allow_single_file = [".js", ".cjs", ".mjs", ".json"]),
+    "auto_configure_reporting": attr.bool(default = True),
     "auto_configure_reporters": attr.bool(default = True),
     "auto_configure_test_sequencer": attr.bool(default = True),
     "run_in_band": attr.bool(default = True),
@@ -63,6 +64,7 @@ def _impl(ctx):
         template = ctx.file._jest_config_template,
         output = generated_config,
         substitutions = {
+            "{{AUTO_CONF_REPORTING}}": "1" if ctx.attr.auto_configure_reporting else "",
             "{{AUTO_CONF_REPORTERS}}": "1" if ctx.attr.auto_configure_reporters else "",
             "{{AUTO_CONF_TEST_SEQUENCER}}": "1" if ctx.attr.auto_configure_test_sequencer else "",
             "{{BAZEL_FILELIST_JSON_SHORT_PATH}}": filelist.short_path,


### PR DESCRIPTION
Attempts to solve https://github.com/aspect-build/rules_jest/pull/294 through a rule attribute instead of an ENV variable

This allows us to upstream the pattern we use internally in a way others can use. We have ejected from the main reporting mechanism and built in our own because of our needs.