### PR TITLE
Change text to text-summary reporter

### DIFF
--- a/jest/private/jest_config_template.mjs
+++ b/jest/private/jest_config_template.mjs
@@ -205,7 +205,7 @@ if (coverageEnabled) {
   }
 
   config.coverageDirectory = coverageDirectory;
-  config.coverageReporters = ["text", ["lcovonly", { file: coverageFile }]];
+  config.coverageReporters = ["text-summary", ["lcovonly", { file: coverageFile }]];
 }
 
 if (process.env.JS_BINARY__LOG_DEBUG) {


### PR DESCRIPTION
The `text` coverage reporter is too verbose and overwhelms the terminal.
Using text-summary produces a summary on the console which is useful for developers,
while still producing the lcovonly report for CI and other tools.
 

### Changes are visible to end-users: yes

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
 
