### PR TITLE
fix: incorrect _hasReporter logic

### DIFF
--- a/jest/private/jest_config_template.mjs
+++ b/jest/private/jest_config_template.mjs
@@ -55,18 +55,13 @@ function _hasReporter(config, name) {
   if (!config.reporters) {
     config.reporters = [];
   }
-  for (const r of config.reporters) {
+  return config.reporters.some((r) => {
     if (Array.isArray(r)) {
-      if (r.length > 0 && r[0] == name) {
-        return true;
-      }
+      return r.length > 0 && r[0] == name;
     } else {
-      if (r == name) {
-        return true;
-      }
+      return r == name;
     }
-  }
-  return false;
+  });
 }
 
 function _addReporter(config, name, reporter = undefined) {


### PR DESCRIPTION
I was recently adjusting the formatting for our junit xml reports (by manually adding the junit reporter in our jest config), and I noticed that my updates only applied if I had `auto_configure_reporters = False`).

Upon further digging, I realized the logic for this `_hasReporter` function incorrectly returns early after only looking at the first element in the `reporters` config array (so essentially this function only indicates if **the first element** in the array matches the provided reporter name).

This change fixes the logic to correctly identify whether a reporter exists in the **entire** reporters config array

---

### Test plan

Happy to add a test for this, but looks like that wouldn't exactly be straightforward given your existing test architecture
