### PR TITLE
refactor: remove MODULE compatibility_level

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,8 +2,6 @@
 
 module(
     name = "aspect_rules_jest",
-    version = "0.0.0",
-    compatibility_level = 1,
 )
 
 # Lower-bounds (minimum) versions for direct runtime dependencies


### PR DESCRIPTION
Bazel now warns about this:

```
WARNING: /rules_jest/MODULE.bazel:3:7: The attribute 'compatibility_level' in module() is a no-op and will be removed in a future Bazel release. Please remove it from your MODULE.bazel file.
```

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
