### PR TITLE
fix: resolve config paths relative to user config location

### DIFF
--- a/e2e/coverage/BUILD.bazel
+++ b/e2e/coverage/BUILD.bazel
@@ -59,3 +59,16 @@ jest_test(
     ],
     node_modules = "//:node_modules",
 )
+
+# rules_jest #347: config in a subdirectory anchors jest's rootDir there, while
+# the instrumented source (foo.js) sits at the package root above it. Coverage
+# must still be attributed to it (regression guard for #2901).
+jest_test(
+    name = "cov_jest_subdir_config",
+    config = "subdir/subdir.jest.config.js",
+    data = [
+        "foo.test.js",
+        ":foo",
+    ],
+    node_modules = "//:node_modules",
+)

--- a/e2e/coverage/subdir/subdir.jest.config.js
+++ b/e2e/coverage/subdir/subdir.jest.config.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/e2e/coverage/test.sh
+++ b/e2e/coverage/test.sh
@@ -39,7 +39,7 @@ for mode in "inline" "split"; do
 		split_flag="--experimental_split_coverage_postprocessing"
 	fi
 
-	for target in cov_jest cov_jest_custom_resolver cov_jest_pkg_resolver cov_jest_cachedir; do
+	for target in cov_jest cov_jest_custom_resolver cov_jest_pkg_resolver cov_jest_cachedir cov_jest_subdir_config; do
 		echo "----- coverage: $target ($mode post-processing) -----"
 		bazel coverage "//:$target" \
 			--instrument_test_targets \

--- a/jest/private/jest_config_template.mjs
+++ b/jest/private/jest_config_template.mjs
@@ -21,6 +21,8 @@ const autoConfReporters = !!"{{AUTO_CONF_REPORTERS}}";
 const autoConfTestSequencer = !!"{{AUTO_CONF_TEST_SEQUENCER}}";
 const userConfigShortPath = "{{USER_CONFIG_SHORT_PATH}}";
 const userConfigPath = "{{USER_CONFIG_PATH}}";
+const rootDirShortPath = "{{ROOT_DIR_SHORT_PATH}}";
+const packageShortPath = "{{PACKAGE_SHORT_PATH}}";
 
 function _resolveRunfilesPath(rootpath) {
   return path.join(
@@ -107,6 +109,23 @@ function _addReporter(config, name, reporter = name) {
 export default async function jestConfig() {
   const config = await _loadUserConfig();
   _verifyJestConfig(config);
+
+  // Pin rootDir to an absolute path so jest leaves it untouched, mirroring jest's
+  // own readConfigFileAndSetRootDir: an absolute user rootDir stays as-is, a
+  // relative one resolves against the anchor, and an absent one defaults to it.
+  // See https://github.com/aspect-build/rules_jest/issues/347.
+  const rootDir = _resolveRunfilesPath(rootDirShortPath);
+  if (config.rootDir) {
+    if (!path.isAbsolute(config.rootDir)) {
+      config.rootDir = path.resolve(rootDir, config.rootDir);
+    }
+  } else {
+    config.rootDir = rootDir;
+  }
+
+  // Default test-discovery roots to the target's package, not rootDir, so the
+  // target's tests are found wherever the config lives. A user `roots` wins.
+  config.roots ||= [_resolveRunfilesPath(packageShortPath)];
 
   config.cacheDirectory ||= path.join(process.env.TEST_TMPDIR, "jest_cache");
 
@@ -233,10 +252,22 @@ export default async function jestConfig() {
     // map already scopes Jest's file universe to this target's `data`, so this
     // glob only ever matches the target's own sources.
     if (!config.collectCoverageFrom) {
-      config.collectCoverageFrom = [
-        "**/*.{cjs,cjx,cts,ctx,js,jsx,mjs,mjx,mts,mtx,ts,tsx}",
-        "!**/node_modules/**",
-      ];
+      // shouldInstrument() matches sources relative to rootDir, so a rootDir in a
+      // subdirectory (see #347) drops the target's sources above it. Emit a glob
+      // per level from rootDir up to the package. Depth 0 yields plain `**/*`.
+      const pkgRel = path.relative(
+        config.rootDir,
+        _resolveRunfilesPath(packageShortPath),
+      );
+      const depth = pkgRel ? pkgRel.split(path.sep).length : 0;
+      config.collectCoverageFrom = [];
+      for (let i = 0; i <= depth; i++) {
+        const prefix = "../".repeat(i);
+        config.collectCoverageFrom.push(
+          prefix + "**/*.{cjs,cjx,cts,ctx,js,jsx,mjs,mjx,mts,mtx,ts,tsx}",
+        );
+        config.collectCoverageFrom.push("!" + prefix + "**/node_modules/**");
+      }
     }
 
     let coverageFile = path.basename(process.env.COVERAGE_OUTPUT_FILE);

--- a/jest/private/jest_test.bzl
+++ b/jest/private/jest_test.bzl
@@ -60,6 +60,26 @@ def _impl(ctx):
         is_executable = False,
     )
 
+    # The target's package directory, as a runfiles-relative path. Use the
+    # generated config rather than ctx.label.package to preserve any external-repo
+    # prefix; it is at <package>/<name>__jest.config.mjs, so strip the filename
+    # plus one directory per slash in the name to recover the package directory.
+    package_short_path = paths.dirname(generated_config.short_path)
+    for _ in range(ctx.label.name.count("/")):
+        package_short_path = paths.dirname(package_short_path)
+
+    # Anchor rootDir at the user's config file when it is co-located in this
+    # package, matching native jest; otherwise (config shared from another package,
+    # or no config) anchor at this target's package.
+    # See https://github.com/aspect-build/rules_jest/issues/347.
+    if user_config and (
+        ctx.attr.config.label.workspace_name == ctx.label.workspace_name and
+        ctx.attr.config.label.package == ctx.label.package
+    ):
+        root_dir_short_path = paths.dirname(user_config.short_path)
+    else:
+        root_dir_short_path = package_short_path
+
     ctx.actions.expand_template(
         template = ctx.file._jest_config_template,
         output = generated_config,
@@ -73,6 +93,8 @@ def _impl(ctx):
             "{{BAZEL_SNAPSHOT_RESOLVER_SHORT_PATH}}": ctx.file.bazel_snapshot_resolver.short_path,
             "{{BAZEL_HASTE_MAP_MODULE_SHORT_PATH}}": ctx.file.bazel_haste_map_module.short_path,
             "{{GENERATED_CONFIG_SHORT_PATH}}": generated_config.short_path,
+            "{{PACKAGE_SHORT_PATH}}": package_short_path,
+            "{{ROOT_DIR_SHORT_PATH}}": root_dir_short_path,
             "{{USER_CONFIG_SHORT_PATH}}": user_config.short_path if user_config else "",
             "{{USER_CONFIG_PATH}}": user_config.path if user_config else "",
         },

--- a/jest/tests/case16/BUILD.bazel
+++ b/jest/tests/case16/BUILD.bazel
@@ -1,0 +1,108 @@
+load("//jest:defs.bzl", "jest_test")
+
+# Case 16: path resolution in the user config must be anchored at the user's
+# config file, independent of the target name or where the config file lives.
+# Regression test for https://github.com/aspect-build/rules_jest/issues/347.
+
+# 16a: slashed target name with the config at the package root. The generated
+# config lands in case16/nested/deep/, but <rootDir> must still resolve to
+# case16/ where the user wrote their config.
+jest_test(
+    name = "nested/deep/test",
+    config = "case16.jest.config.js",
+    data = [
+        "case16.setup.js",
+        "case16.test.js",
+    ],
+    node_modules = "//:node_modules",
+)
+
+# 16b: config in a subdirectory. <rootDir> must resolve to that subdirectory,
+# not to the package directory where the generated config lands.
+jest_test(
+    name = "subdir_config",
+    config = "subdir/case16-subdir.jest.config.js",
+    data = [
+        "subdir/case16-subdir.setup.js",
+        "subdir/case16-subdir.test.js",
+    ],
+    node_modules = "//:node_modules",
+)
+
+# 16e: config in a subdirectory but a test file at the package root. Discovery
+# must still find the package-root test, i.e. rootDir narrowing to the config's
+# subdir must not drop test files that live above it.
+jest_test(
+    name = "subdir_config_root_test",
+    config = "subdir/case16-subdir.jest.config.js",
+    data = [
+        "root_level.test.js",
+        "subdir/case16-subdir.setup.js",
+    ],
+    node_modules = "//:node_modules",
+)
+
+# 16c: slashed target name with no config. rootDir must still be the package so
+# the target's own test files are discovered.
+jest_test(
+    name = "nested/deep/noconfig",
+    data = ["noconfig.test.js"],
+    node_modules = "//:node_modules",
+)
+
+# 16d: slashed target name with a config shared from another package. rootDir
+# must be this package (not the foreign config's package) so the target's own
+# test files are discovered.
+jest_test(
+    name = "nested/deep/shared_config",
+    config = "//jest/tests/configs:basic",
+    data = ["noconfig.test.js"],
+    node_modules = "//:node_modules",
+)
+
+# 16f: snapshots with a slashed target name. Snapshot resolution must still find
+# the __snapshots__ dir next to the test file, independent of the target name.
+jest_test(
+    name = "nested/deep/snapshot",
+    config = "case16.jest.config.js",
+    data = [
+        "case16.setup.js",
+        "snapshot.test.js",
+    ],
+    node_modules = "//:node_modules",
+    snapshots = True,
+)
+
+# 16g: a relative user `rootDir` must resolve against the config anchor.
+jest_test(
+    name = "rootdir_relative",
+    config = "case16-rootdir-rel.jest.config.js",
+    data = [
+        "rootdir_rel/rootdir_rel.setup.js",
+        "rootdir_rel/rootdir_rel.test.js",
+    ],
+    node_modules = "//:node_modules",
+)
+
+# 16h: an absolute user `rootDir` (here `__dirname`) must be left untouched.
+jest_test(
+    name = "rootdir_absolute",
+    config = "rootdir_abs/case16-rootdir-abs.jest.config.js",
+    data = [
+        "rootdir_abs/rootdir_abs.setup.js",
+        "rootdir_abs/rootdir_abs.test.js",
+    ],
+    node_modules = "//:node_modules",
+)
+
+# 16i: a user-supplied `roots` must be preserved. Only `included/` is in scope;
+# the poison test under `excluded/` throws if it is ever discovered.
+jest_test(
+    name = "user_roots",
+    config = "case16-roots.jest.config.js",
+    data = [
+        "excluded/poison.test.js",
+        "included/good.test.js",
+    ],
+    node_modules = "//:node_modules",
+)

--- a/jest/tests/case16/__snapshots__/snapshot.test.js.snap
+++ b/jest/tests/case16/__snapshots__/snapshot.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`snapshots resolve correctly with a slashed target name 1`] = `
+{
+  "value": 16,
+}
+`;

--- a/jest/tests/case16/case16-rootdir-rel.jest.config.js
+++ b/jest/tests/case16/case16-rootdir-rel.jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  testEnvironment: "node",
+  testMatch: ["**/*.test.js"],
+  // A relative rootDir must resolve against the config's own directory.
+  rootDir: "rootdir_rel",
+  setupFiles: ["<rootDir>/rootdir_rel.setup.js"],
+};

--- a/jest/tests/case16/case16-roots.jest.config.js
+++ b/jest/tests/case16/case16-roots.jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: "node",
+  testMatch: ["**/*.test.js"],
+  // A user-supplied `roots` must be preserved. Only `included/` is in scope.
+  roots: ["<rootDir>/included"],
+};

--- a/jest/tests/case16/case16.jest.config.js
+++ b/jest/tests/case16/case16.jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  testEnvironment: "node",
+  testMatch: ["**/*.test.js"],
+  setupFiles: ["<rootDir>/case16.setup.js"],
+};

--- a/jest/tests/case16/case16.setup.js
+++ b/jest/tests/case16/case16.setup.js
@@ -1,0 +1,1 @@
+global.CASE16_SETUP_VALUE = 16;

--- a/jest/tests/case16/case16.test.js
+++ b/jest/tests/case16/case16.test.js
@@ -1,0 +1,3 @@
+test("<rootDir> resolves to the user config dir regardless of target name", () => {
+  expect(global.CASE16_SETUP_VALUE).toBe(16);
+});

--- a/jest/tests/case16/excluded/poison.test.js
+++ b/jest/tests/case16/excluded/poison.test.js
@@ -1,0 +1,4 @@
+// In `data` but outside the user-supplied `roots`; running it means `roots` was not preserved.
+test("a test outside the user-supplied roots must not be discovered", () => {
+  throw new Error("discovered a test outside the user-supplied roots");
+});

--- a/jest/tests/case16/included/good.test.js
+++ b/jest/tests/case16/included/good.test.js
@@ -1,0 +1,3 @@
+test("a test inside the user-supplied roots is discovered", () => {
+  expect(1).toBe(1);
+});

--- a/jest/tests/case16/noconfig.test.js
+++ b/jest/tests/case16/noconfig.test.js
@@ -1,0 +1,3 @@
+test("test discovery works with a slashed target name and no config", () => {
+  expect(1).toBe(1);
+});

--- a/jest/tests/case16/root_level.test.js
+++ b/jest/tests/case16/root_level.test.js
@@ -1,0 +1,3 @@
+test("a package-root test runs even when the config lives in a subdir", () => {
+  expect(2).toBe(2);
+});

--- a/jest/tests/case16/rootdir_abs/case16-rootdir-abs.jest.config.js
+++ b/jest/tests/case16/rootdir_abs/case16-rootdir-abs.jest.config.js
@@ -1,0 +1,7 @@
+// `__dirname` is an absolute rootDir, so `<rootDir>` must resolve back to it.
+module.exports = {
+  testEnvironment: "node",
+  testMatch: ["**/*.test.js"],
+  rootDir: __dirname,
+  setupFiles: ["<rootDir>/rootdir_abs.setup.js"],
+};

--- a/jest/tests/case16/rootdir_abs/rootdir_abs.setup.js
+++ b/jest/tests/case16/rootdir_abs/rootdir_abs.setup.js
@@ -1,0 +1,1 @@
+global.CASE16_ROOTDIR_ABS = "abs";

--- a/jest/tests/case16/rootdir_abs/rootdir_abs.test.js
+++ b/jest/tests/case16/rootdir_abs/rootdir_abs.test.js
@@ -1,0 +1,4 @@
+// A wrong rootDir would fail to load the `<rootDir>` setup file.
+test("an absolute user rootDir is left untouched", () => {
+  expect(global.CASE16_ROOTDIR_ABS).toBe("abs");
+});

--- a/jest/tests/case16/rootdir_rel/rootdir_rel.setup.js
+++ b/jest/tests/case16/rootdir_rel/rootdir_rel.setup.js
@@ -1,0 +1,1 @@
+global.CASE16_ROOTDIR_REL = "rel";

--- a/jest/tests/case16/rootdir_rel/rootdir_rel.test.js
+++ b/jest/tests/case16/rootdir_rel/rootdir_rel.test.js
@@ -1,0 +1,4 @@
+// A wrong rootDir would fail to load the `<rootDir>` setup file.
+test("a relative user rootDir resolves against the config anchor", () => {
+  expect(global.CASE16_ROOTDIR_REL).toBe("rel");
+});

--- a/jest/tests/case16/snapshot.test.js
+++ b/jest/tests/case16/snapshot.test.js
@@ -1,0 +1,3 @@
+test("snapshots resolve correctly with a slashed target name", () => {
+  expect({ value: 16 }).toMatchSnapshot();
+});

--- a/jest/tests/case16/subdir/case16-subdir.jest.config.js
+++ b/jest/tests/case16/subdir/case16-subdir.jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  testEnvironment: "node",
+  testMatch: ["**/*.test.js"],
+  setupFiles: ["<rootDir>/case16-subdir.setup.js"],
+};

--- a/jest/tests/case16/subdir/case16-subdir.setup.js
+++ b/jest/tests/case16/subdir/case16-subdir.setup.js
@@ -1,0 +1,1 @@
+global.CASE16_SUBDIR_SETUP_VALUE = 17;

--- a/jest/tests/case16/subdir/case16-subdir.test.js
+++ b/jest/tests/case16/subdir/case16-subdir.test.js
@@ -1,0 +1,3 @@
+test("<rootDir> resolves to the user config dir when config is in a subdir", () => {
+  expect(global.CASE16_SUBDIR_SETUP_VALUE).toBe(17);
+});


### PR DESCRIPTION
Fixes #347

### Changes are visible to end-users: yes

Path resolution in user Jest configs no longer depends on the `jest_test`
target name or on where the config file is placed.

### Problem

`jest_test` generates a wrapper config at `<package>/<name>__jest.config.mjs`.
Jest derives `rootDir` (and the test-discovery `roots`) from the config file it
loads, so both followed the **target name** — a name containing slashes lands the
generated config in a subdirectory, shifting `rootDir` and breaking `<rootDir>`
tokens and relative paths in the user's config. Resolution also differed
depending on where the user placed their own config file, rather than resolving
relative to that file as Jest does natively.

### Fix

- `jest_test.bzl` computes two runfiles-relative anchors and passes them to the
  template: the target's package directory, and a `rootDir` anchor. A config
  co-located in the target's package anchors `rootDir` at the config file's
  directory (matching Jest's `readConfigFileAndSetRootDir`); a config shared from
  another package, or no config at all, anchors at the target's package.
- The config template sets an absolute `config.rootDir` (so Jest leaves it
  untouched), resolving a relative user-supplied `rootDir` against the anchor.
  Because `rootDir` now follows the config location, `config.roots` defaults to
  the target's package so the target's own test files are still discovered
  regardless of where the config lives. A user-supplied `roots` is preserved.

### Test plan

- New test cases added (`jest/tests/case16/`): slashed target name with a
  co-located config, config in a subdirectory, a package-root test with the
  config in a subdirectory (test-discovery scope), no config, a config shared
  from another package, and snapshots under a slashed target name.
- Verified the full suite passes (`//jest/...` and `//example/...`), and the
  snapshot-update path produces no spurious diffs.
